### PR TITLE
Deixar os menus um pouquinho mais largos

### DIFF
--- a/themes/temaic/static/css/style.css
+++ b/themes/temaic/static/css/style.css
@@ -259,10 +259,8 @@ header a:hover {
 
 /* Se refere às subcategorias do menu escondido */
 #main-header > .principal > li > ul > li {
-	/*border: 1px solid var(--cor-borda-cinza);*/
-	width: 200px;
-	padding: 20px;
-	border-radius: 10px;
+	width: 250px;
+	padding: 10px;
 }
 
 /* Se refere aos títulos das subcategorias do menu escondido */


### PR DESCRIPTION
Acho que se deixarmos um pouco mais largo e diminuirmos o padding, menos itens do Menu precisarão de mais de uma linha. Acho que o largo padding atual é uma relíquia da época que ainda tinha aquela borda interna. Mas sinta-se livre pra ajustar os números.