### PR TITLE
Remover bordas dos cards de pessoal

### DIFF
--- a/themes/temaic/static/css/style.css
+++ b/themes/temaic/static/css/style.css
@@ -604,7 +604,7 @@ article hr {
 	margin: 20px 0;
 	list-style: none;
 	display: grid;
-	gap: 50px;
+	gap: 20px;
 	grid-template-columns: 1fr 1fr;
 
 	font-family: "Montserrat", sans-serif;
@@ -621,17 +621,14 @@ article hr {
 
 
 .card-pessoal {
-	min-width: 300px;
+	min-width: 400px;
+	margin: 0px;
+	padding: 0px;
 
-	border: 1px solid var(--cor-borda-cinza);
-	border-radius: 10px;
-
-	background-color: var(--cor-fundo);
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
 
-	padding: 20px;
 }
 
 .card-pessoal-largo {


### PR DESCRIPTION
Acho que antes tinha muito espaço em branco entre os cards.

- Com cards mais largos, todos os nomes de pessoas cabem em uma linha.
- Removi as bordas e deixei mais compacto
- A coluna da esquerda agora está colada na borda esquerda da página.