### PR TITLE
Deixar os submenus sempre abertos no mobile.

### DIFF
--- a/themes/temaic/static/css/style.css
+++ b/themes/temaic/static/css/style.css
@@ -426,12 +426,7 @@ body > header a:hover {
 		width: 100%;
 		background: none;
 		border: none;
-		display: none;
-	}
 
-	#main-header > .principal > li:focus > ul,
-	#main-header > .principal > li:focus-within > ul,
-	#main-header > .principal > li:hover > ul {
 		display: flex;
 		clip-path: inset(-50px 0 0 0);
 		transition-delay: 200ms;


### PR DESCRIPTION
Pode não ser o ideal, mas é bem mais simples e é mais usável do que a versão atual com o hover.